### PR TITLE
Fix SortedArray#bsearch_index with comparable operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Fix `SortedArray#bsearch_index` to work with comparable operator `<=>`
+
 ## [0.1.1] - 2024-04-25
 
 - Update README.md so rubydoc.info formats correctly

--- a/lib/sorted_containers/sorted_array.rb
+++ b/lib/sorted_containers/sorted_array.rb
@@ -355,9 +355,7 @@ module SortedContainers
     def bsearch_index(&block)
       return nil if @maxes.empty?
 
-      pos = @maxes.bsearch_index(&block)
-
-      return nil if pos.nil?
+      pos = @maxes.bsearch_index(&block) || 0
 
       idx = @lists[pos].bsearch_index(&block)
       loc(pos, idx)

--- a/spec/sorted_array_spec.rb
+++ b/spec/sorted_array_spec.rb
@@ -420,6 +420,12 @@ RSpec.describe SortedContainers::SortedArray do
       array = SortedContainers::SortedArray.new(basic_array, load_factor: 2)
       expect(array.bsearch { |x| x >= 3 }).to eq(basic_array.bsearch { |x| x >= 3 })
     end
+
+    it "should work with the comparable operator" do
+      basic_array = [1, 2, 3, 4, 5]
+      array = SortedContainers::SortedArray.new(basic_array)
+      expect(array.bsearch { |x| x <=> 3 }).to eq(basic_array.bsearch { |x| x <=> 3 })
+    end
   end
 
   describe "bsearch_index" do


### PR DESCRIPTION
Ruby Array allows `[1, 2, 3, 4, 5].bsearch_index { |n| 3 <=> n } #=> 2`. So it should work against SortedArray too.
